### PR TITLE
Fix JSON output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ xcuserdata/
 ## Xcode 8 and earlier
 *.xcscmblueprint
 *.xccheckout
+
+.git-credentials

--- a/gpuPerformanceStatistics/gpuPerformanceStatistics/main.swift
+++ b/gpuPerformanceStatistics/gpuPerformanceStatistics/main.swift
@@ -22,19 +22,14 @@ func queryPerformanceStatistic(matchingString: String) {
     var acceleratorService: io_object_t = IOIteratorNext(iterator)
     while acceleratorService != 0 {
         let performanceStats = IORegistryEntryCreateCFProperty(acceleratorService, "PerformanceStatistics" as CFString, kCFAllocatorDefault, 0)
-        var first = true
         
         if let stats = performanceStats?.takeRetainedValue() as? [String: Any] {
-            // Do something with the performance statistics
-            print(stats)
-            print ("{")
-         
-            for (key, value) in stats {
-                if (!(first == true)) { print (",") }
-                else { first = false }
-                print ("\""+key+"\""," : ", value, terminator: "")
+            if let jsonData = try? JSONSerialization.data(withJSONObject: stats, options: [.prettyPrinted]),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                print(jsonString)
+            } else {
+                print("Error: Failed to serialize JSON")
             }
-            print ("}")
         }
         
         IOObjectRelease(acceleratorService)


### PR DESCRIPTION
Previously, the syntax of the output of this script was not valid JSON. 

```
> gpuPerformanceStatistics IOAccelerator 

["Allocated PB Size": 18087936, "Tiler Utilization %": 3, "TiledSceneBytes": 327680, "Renderer Utilization %": 3, "Alloc system memory": 417021952, "recoveryCount": 0, "In use system memory": 102170624, "Device Utilization %": 3, "SplitSceneCount": 0]
{
"Allocated PB Size"  :  18087936,
"Tiler Utilization %"  :  3,
"TiledSceneBytes"  :  327680,
"Renderer Utilization %"  :  3,
"Alloc system memory"  :  417021952,
"recoveryCount"  :  0,
"In use system memory"  :  102170624,
"Device Utilization %"  :  3,
"SplitSceneCount"  :  0}

```


This change removes the extraneous list and serializes JSON to ensure proper syntax. 
```
> gpuPerformanceStatistics IOAccelerator
{
  "SplitSceneCount" : 0,
  "Alloc system memory" : 416595968,
  "Device Utilization %" : 6,
  "Allocated PB Size" : 18087936,
  "In use system memory" : 106086400,
  "Tiler Utilization %" : 6,
  "Renderer Utilization %" : 6,
  "recoveryCount" : 0,
  "TiledSceneBytes" : 327680
}
```

Tested that this compiles and fixes the `E! [inputs.execd] Error in plugin: parse error: invalid character ':' after top-level value` errors our telegraf agent logs were reporting. 